### PR TITLE
Recommend microsoft tslint plugin instead of deprecated one

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }


### PR DESCRIPTION
[eg2.tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) has been deprecated in favor of a [Microsoft supported alternative](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin)

https://github.com/Microsoft/vscode-typescript-tslint-plugin
