### PR TITLE
URI-encode API calls which were being rejected on some servers

### DIFF
--- a/src/jenkinsService.ts
+++ b/src/jenkinsService.ts
@@ -387,7 +387,7 @@ export class JenkinsService {
                 rootUrl = rootUrl === undefined ? this._jenkinsUri : rootUrl;
                 rootUrl = this.fromUrlFormat(rootUrl);
                 let url = `${rootUrl}/api/json?tree=jobs[${this._jobProps},jobs[${this._jobProps},jobs[${this._jobProps}]]]`;
-                let requestPromise = request.get(url);
+                let requestPromise = request.get(encodeURI(url));
                 token?.onCancellationRequested(() => {
                     requestPromise.abort();
                     resolve([]);


### PR DESCRIPTION
Tested locally and fixes https://github.com/tabeyti/jenkins-jack/issues/59

Of note, there are three other calls to request.get(url) which you may want to consider URI encoding.